### PR TITLE
Add license metadata to PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     version="1.3.0",
     description="Embeds text documents using sent2vec",
     author="New Knowledge",
+    license='BSD-3-Clause',
     packages=["nk_sent2vec"],
     package_data={"": ["*.h, *.cc", "*Makefile"]},
     include_package_data=True,


### PR DESCRIPTION
The package shows as `UNKNOWN` right now and people have to come to the repository to find the LICENSE file.